### PR TITLE
Set default null for optional fields

### DIFF
--- a/src/main/scala/in/dreamlabs/xmlavro/SchemaBuilder.scala
+++ b/src/main/scala/in/dreamlabs/xmlavro/SchemaBuilder.scala
@@ -7,21 +7,14 @@ import org.apache.avro.Schema
 import org.apache.avro.Schema.Field
 import org.apache.xerces.dom.DOMInputImpl
 import org.apache.xerces.impl.Constants
-import org.apache.xerces.impl.xs.{
-  SchemaGrammar,
-  XMLSchemaLoader,
-  XSComplexTypeDecl
-}
+import org.apache.xerces.impl.xs.{SchemaGrammar, XMLSchemaLoader, XSComplexTypeDecl}
 import org.apache.xerces.xni.parser.{XMLEntityResolver, XMLInputSource}
 import org.apache.xerces.xni.{XMLResourceIdentifier, XNIException}
-import org.apache.xerces.xs.XSConstants.{
-  ATTRIBUTE_DECLARATION,
-  ELEMENT_DECLARATION,
-  MODEL_GROUP,
-  WILDCARD
-}
+import org.apache.xerces.xs.XSConstants.{ATTRIBUTE_DECLARATION, ELEMENT_DECLARATION, MODEL_GROUP, WILDCARD}
 import org.apache.xerces.xs.XSTypeDefinition.{COMPLEX_TYPE, SIMPLE_TYPE}
 import org.apache.xerces.xs._
+import org.codehaus.jackson.JsonNode
+import org.codehaus.jackson.node.NullNode
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -268,10 +261,13 @@ final class SchemaBuilder(config: XSDConfig) {
           case ATTRIBUTE_DECLARATION =>
             (ele.asInstanceOf[XSAttributeDeclaration].getTypeDefinition, true)
         }
+
         val fieldSchema: Schema = processType(eleType, optional, array)
+        val defaultValue: JsonNode = if (optional) NullNode.getInstance() else null
 
         val field: Field =
-          new Field(validName(ele.getName).get, fieldSchema, null, null)
+          new Field(validName(ele.getName).get, fieldSchema, null, defaultValue)
+
         field.addProp(XNode.SOURCE, XNode(ele, attribute).source)
 
         if (eleType.getTypeCategory == SIMPLE_TYPE) {


### PR DESCRIPTION
Fixes #3 

Instead of supplying null as the defaultValue (resulting in no default value), a JsonNode with value null is supplied for those elements that are optional. 

The only downside is that this creates a direct dependency on Jackson, which was only a transitive dependency before, but Avro requires us to supply a JsonNode.