### PR TITLE
Made the mapping behavior of xs:decimal types configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,30 @@ XSD:
                                 #   "string" (the default) maps xs:time types to Avro "string".
                                 #   "time-micros" maps xs:time types to Avro "time-micros" logical type annotating a "long". 
                                 #   "time-millis" maps xs:time types to Avro "time-millis" logical type annotating a "long".
+                                #
+    xsDecimal:                  # Configurations controlling the mapping of xs:decimal XML types
+                                #
+     avroType: "decimal"        #   Configures the Avro type mapping of xs:Decimal derived xml types.
+                                #   Possible values are: [ double | string | decimal ]
+                                #   - "double" (the default) maps xs:decimal types to Avro "double".
+                                #   - "string" maps xs:decimal types to Avro "string".
+                                #   - "decimal" maps xs:decimal types to Avro "decimal" logical types annotating "bytes".
+                                #   When using the "decimal" option, the mandatory precision and scale properties of the Avro
+                                #   decimal type are picked up from any xs:totalDigits and xs:fractionDigits restriction facets, if any.
+                                #   In the absense of these restriction facets, the mapping will instead fall back to using a backup strategy defined
+                                #   by a combination of the fallbackType, fallbackPrecision and fallbackScale configurations. 
+                                #     
+     fallbackType: "string"     # Configures a fallback type mapping for xs:decimal types with unrestricted precision and scale. (i.e. types without
+                                #   declared xs:totalDigits and xs:fractionDigits restriction facets). This configuration is ignored, unless the
+                                #   avroType setting is configured to "decimal".
+                                #   The possible values are: [ string | double | decimal ]
+                                #   All options are identical to those described under the avroType configuration, the only exception being 
+                                #   "decimal" that uses the fallbackPrecision and fallbackScale configurations as a defaults for missing
+                                #   precision and scale information.
+                                #   
+     fallbackPrecision: 5       #  Configures the fallback precision for decimal types without declared xs:totalDigits
+                                #    and restriction. Required when fallbackType is set to "decimal".
+                                #
+     fallbackScale: 3           #  Configures the fallback scale for decimal types without declared xs:fractionDigits restriction.
+                                #   Required when fallbackType is set to "decimal".
 ```

--- a/src/main/scala/in/dreamlabs/xmlavro/config/Config.scala
+++ b/src/main/scala/in/dreamlabs/xmlavro/config/Config.scala
@@ -121,6 +121,7 @@ object LogicalType {
     * Dummy logical type for handling values as long without indicating a logicalType.
     */
   val LONG = "long"
+
 }
 
 class LogicalTypesConfig {
@@ -131,6 +132,8 @@ class LogicalTypesConfig {
   var xsTime: String = LogicalType.STRING
   @BeanProperty
   var xsDate: String = LogicalType.STRING
+  @BeanProperty
+  var xsDecimal: XSDecimalConfig = new XSDecimalConfig
 
   def validate(): Unit = {
     xsDateTime = Option(xsDateTime) getOrElse ""
@@ -158,6 +161,65 @@ class LogicalTypesConfig {
       case _ =>
         throw new IllegalArgumentException("Invalid configuration for xs:date logical type.")
     }
+
+    xsDecimal = Option(xsDecimal) getOrElse new XSDecimalConfig
+    xsDecimal.validate()
+  }
+
+}
+
+object XSDecimalConfigLogicalType {
+  val DOUBLE = "double"
+
+  val STRING = "string"
+
+  val DECIMAL = "decimal"
+}
+
+
+class XSDecimalConfig {
+  @BeanProperty
+  var avroType = XSDecimalConfigLogicalType.DOUBLE
+  @BeanProperty
+  var fallbackType = XSDecimalConfigLogicalType.STRING
+  @BeanProperty
+  var fallbackPrecision : Integer = null
+  @BeanProperty
+  var fallbackScale : Integer = 0
+
+  def validate(): Unit = {
+
+    val acceptedAvroTypes = List(
+      XSDecimalConfigLogicalType.DECIMAL,
+      XSDecimalConfigLogicalType.DOUBLE,
+      XSDecimalConfigLogicalType.STRING
+    )
+
+    if (!acceptedAvroTypes.contains(avroType)) {
+      throw new IllegalArgumentException(s"Invalid configuration value '$avroType' for xsDecimal avroType.")
+    }
+
+    if (!acceptedAvroTypes.contains(fallbackType)) {
+      throw new IllegalArgumentException(s"Invalid configuration value '$fallbackType' for xsDecimal fallbackType.")
+    }
+
+    if (fallbackType == XSDecimalConfigLogicalType.DECIMAL) {
+      if (Option(fallbackPrecision) isEmpty) {
+        throw new IllegalArgumentException(s"Missing xsDecimal fallbackPrecision " +
+          s"configuration for '$fallbackType' fallback type.")
+      }
+      if (Option(fallbackScale) isEmpty) {
+        throw new IllegalArgumentException(s"Missing xsDecimal fallbackScale " +
+          s"configuration for '$fallbackType' fallback type.")
+      }
+      if (fallbackPrecision <= 0) {
+        throw new IllegalArgumentException(s"Invalid configuration value $fallbackPrecision for xsDecimal fallbackPrecision.")
+      }
+      if (fallbackScale <= 0 || fallbackScale > fallbackPrecision) {
+        throw new IllegalArgumentException(s"Invalid configuration value $fallbackScale for xsDecimal fallbackScale.")
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
Allows `xs:decimal` XML types to be mapped as either Avro `double`, `string` or `decimal` logical types.
The default behavior matches that of previous xml-avro versions (i.e `xs:decimal` types are mapped to double).

When mapping XML decimal types to Avro logical decimals, the new behavior will use the available  `xs:totalDigits` and `xs:fractionDigits` restriction facets to set the precision and scale properties of the logical type.

In cases where the mandatory percision/scale information is missing due to the lack of required restriction facets, the mapping will fall back to using a combination of the following new configuration options: `fallbackType`, `fallbackPrecision` and `fallbackScale`.